### PR TITLE
Checkout action with fetch depth = 2

### DIFF
--- a/.github/scripts/get_pr_matrix.sh
+++ b/.github/scripts/get_pr_matrix.sh
@@ -2,7 +2,7 @@
 
 for image in $(ls images)
 do
-  git fetch --depth=1 origin main
+  git fetch origin main --depth=1
   if [ -z "$(git diff FETCH_HEAD HEAD --name-only -- images/$image)" ]
   then
     include=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,31 +21,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3.0.2
-        - fetch-depth: 2
-
-      - name: What happens with git show??
-        run: |
-          for image in $(ls images)
-          do
-            if [ -z "$(git show --first-parent --name-only -- images/$image)" ]
-            then
-              include=false
-            else
-              include=true
-            fi
-
-            set -x
-            git show --first-parent --name-only -- images/$image
-            set +x
-
-            echo "$image changed: $include"
-            if $include
-            then
-              echo "Putting it in the list!"
-            fi
-          done
-          exit 1
-
+        with:
+          fetch-depth: 2
       - id: set-matrix
         run: echo "::set-output name=matrix::{'include':[$(.github/scripts/get_main_matrix.sh | paste -sd ',' -)]}"
       - id: set-repo

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -12,6 +12,8 @@ Basically `node:slim` with a few missing basics installed:
 - openssh-client
 - vim
 
+Probably better off using `node:latest`, tbh...
+
 ## Use with VSCode
 
 > TODO: update with new devcontainers spec...


### PR DESCRIPTION
# Build related changes

<!--
Please try to limit your pull request to one type, submit multiple pull requests if needed.
Copy/Keep the appropriate heading out of this comment:
# Bugfix
# Feature
# Code style update (formatting, renaming)
# Refactoring (no functional changes, no api changes)
# Build related changes
# Documentation content changes

# Other
> (please describe):
-->

## Pull request checklist

<!-- Checkboxes can be checked like this: [x] -->

Please check if your PR fulfills the following requirements:
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [x] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.

The main workflow was not filtering the changed docker directories because by default, [actions/checkout](https://github.com/actions/checkout#usage) does a shallow clone with depth=1. `git show` only has 1 commit to look at, then.

A fetch depth of 2 happens to fetch the previous commit AND the HEAD of the merged branch.

`git log --oneline --decorate --graph --all`

```text
*   74e73b5 (HEAD -> main, origin/main, origin/HEAD) Merge pull request #29 from SupaStuff/git_show4
|\
| * b7e0f3f (grafted) refactor: move depth flag for no reason
* 3ee4a96 (grafted) Merge pull request #28 from SupaStuff/git_show3
```

This is all that's needed to see what files were changed by the merge!

## Is this related to any currently open issues?

Closes #25 

<!--
Mention the issue(s) this is related to. For more info, see:
https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically

For multiple issues, use a bulleted list. i.e:

Related to means only some progress was made. The others will close the issue once it's merged/
 -->

## What tests cover this change?
N/A
